### PR TITLE
Updated modal.js to use ng-class

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -10,26 +10,12 @@ angular.module('angularify.semantic.modal', [])
         scope: {
             model: '=ngModel'
         },
-        template: "<div class=\"{{ modal_class }}\">" + 
-                    "<div class=\"ui test modal transition visible active\" style=\"margin-top: -189px;\" ng-transclude>" +
+        template: "<div class=\"ui dimmer page\" ng-class=\"{ active: model }\">" + 
+                    "<div class=\"ui test modal transition visible\" style=\"margin-top: -189px;\"  ng-transclude>" +
                     "</div>" +
                   "</div>",
         link: function (scope, element, attrs) {
-            if (scope.model == true) {
-                scope.modal_class = 'ui dimmer page active';
-            } else{
-                scope.model = false;
-                scope.modal_class = 'ui dimmer page';
-            }
-
-            scope.$watch('model', function (val) {
-                if (scope.model == true) {
-                    scope.modal_class = 'ui dimmer page active';
-                } else{
-                    scope.model = false;
-                    scope.modal_class = 'ui dimmer page';
-                }
-            });
+            
         }
     }
 });


### PR DESCRIPTION
Instead of using the link function to add a watch that only changes the class list of the dimmer element. Just use ng-class to watch the model instead, then you do not need any code in your link function.

The modal directive didn't have any tests associated with it. I can certainly write some if you require.
