### PR TITLE
Fix scope issue with accordion

### DIFF
--- a/src/accordion/accordion.js
+++ b/src/accordion/accordion.js
@@ -8,9 +8,9 @@ angular.module('angularify.semantic.accordion', [])
     this.add_accordion = function(scope) {
         $scope.accordions.push(scope);
         
-        
+        var _this = this;
         scope.$on('$destroy', function (event) {
-            this.remove_accordion(scope);
+            _this.remove_accordion(scope);
         });
         
         return $scope.accordions;


### PR DESCRIPTION
Fix issue with scope in add_accordion.  When on $destroy is called the `this` was not scoped appropriately.
