### PR TITLE
Make dropdown openable

### DIFF
--- a/src/dropdown/docs/controllers.js
+++ b/src/dropdown/docs/controllers.js
@@ -1,6 +1,17 @@
-var dropdownApp = angular.module('dropdownApp', ['angularify.semantic.dropdown']);
+
+angular
+  .module('dropdownApp', ['angularify.semantic.dropdown'])
+  .controller('RootCtrl', RootCtrl);
 
 function RootCtrl ($scope) {
     $scope.dropdown_model = 'item3';
+
+    $scope.dropdown_repeat_model = 'item1';
+    $scope.dropdown_items = [
+      'item1',
+      'item2',
+      'item3',
+      'item4'
+    ];
 }
 

--- a/src/dropdown/docs/demo.html
+++ b/src/dropdown/docs/demo.html
@@ -3,17 +3,32 @@
 <head>
   <meta charset="utf-8" />
   <title>Semantic UI + Angular.JS</title>
-  <link href="../../../bower_components/semantic/build/packaged/css/semantic.min.css" rel="stylesheet" type="text/css" /> 
+  <link href="../../../bower_components/semantic/dist/semantic.min.css" rel="stylesheet" type="text/css" />
 </head>
 <body ng-controller="RootCtrl">
-    <dropdown title="my dropdown" ng-model="dropdown_model" open="true">
+    <h2>Basic</h2>
+
+    <dropdown title="my dropdown" ng-model="dropdown_model" open="false">
       <dropdown-group>item1</dropdown-group>
       <dropdown-group>item2</dropdown-group>
       <dropdown-group>item3</dropdown-group>
       <dropdown-group>item4</dropdown-group>
     </dropdown>
+
+    <p class="ui info message">
+      Current selection is: {{ dropdown_model }}
+    </p>
+
+    <h2>With ng-repeat</h2>
+
+    <dropdown title="my dropdown" ng-model="dropdown_repeat_model" open="false">
+      <dropdown-group title="item" ng-repeat="item in dropdown_items">{{ item }}</dropdown-group>
+    </dropdown>
+
+    <p class="ui info message">
+      Current selection is: {{ dropdown_repeat_model }}
+    </p>
     <script src="../../../bower_components/angular/angular.min.js" type="text/javascript"></script>
-    <script src="../../angularify.semantic.js" type="text/javascript"></script>
     <script src="../dropdown.js" type="text/javascript"></script>
     <script src="controllers.js" type="text/javascript"></script>
 </body>

--- a/src/dropdown/test/dropdown.spec.js
+++ b/src/dropdown/test/dropdown.spec.js
@@ -9,7 +9,7 @@ describe('dropdown', function () {
 
     describe('controller', function () {
         var ctrl, $element, $attrs;
-        
+
         beforeEach(inject(function($controller) {
           $attrs = {}; $element = {};
           ctrl = $controller('DropDownController', { $scope: $scope });
@@ -41,6 +41,6 @@ describe('dropdown', function () {
                 ctrl.update_title('title');
                 expect(scope.title).toBe('title');
             })
-        });    
+        });
     });
 });


### PR DESCRIPTION
I wasn't able to use the dropdown because of missing classes on `<div class="menu">`.  
This div must have the following classes to work:
```html
<div class="menu transition visible">
</div>
```
The `transition` class is not compulsory but add a nice effect
After those change done, I got other issues:
- The `scope.open` property was supposed to be string but we stored a boolean. So, an equality check with a boolean value failed
- Sometime, the `scope.model` was updated with the original title and not `undefined`
- If `scope.model == undefined`, the title of the dropdown was set to the `undefined` instead of the original name 
- The `var title` in the dropdown-group wasn't used. So, if no title was provided for this directive, after selection, we set the dropdown title to `undefined`

Those points are fixed.
Dropdown closed:
![screen shot 2015-03-14 at 3 54 08 pm](https://cloud.githubusercontent.com/assets/2843268/6651914/bc4363ca-ca62-11e4-8386-d4172c4f418d.png)
Dropdown opened:
![screen shot 2015-03-14 at 3 54 03 pm](https://cloud.githubusercontent.com/assets/2843268/6651916/c4d8950a-ca62-11e4-8553-2c83ef3ea834.png)

This pull-request also include an update of the `dropdown/doc/` files