### PR TITLE
Click on a previous step makes it active

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,6 +3,7 @@ basePath = '.';
 files = [
   JASMINE,
   JASMINE_ADAPTER,
+  'bower_components/jquery/dist/jquery.min.js',
   'bower_components/angular/angular.min.js',
   'bower_components/angular-mocks/angular-mocks.js',
   'src/**/*.js',

--- a/src/sidebar/test/sidebar.spec.js
+++ b/src/sidebar/test/sidebar.spec.js
@@ -15,23 +15,23 @@ describe('sidebar', function () {
           ctrl = $controller('SideBarController', { $scope: $scope });
         }));
 
-        describe('add_sidebar_item', function() {
-            it("SideBarController add_sidebar_item test", function(){
-                var acc1, acc2;
-                ctrl.add_sidebar_items(acc1 = $scope.$new());
-                ctrl.add_sidebar_items(acc2 = $scope.$new());
-                expect($scope.side_bar_items.length).toBe(2);
-            });
-        });
-
-        describe('remove_side_bar_item', function(){
-            it("SideBarController remove_side_bar test", function(){
-                var acc1, acc2;
-                ctrl.add_sidebar_items(acc1 = $scope.$new());
-                ctrl.add_sidebar_items(acc2 = $scope.$new());
-                ctrl.remove_side_bar_item(acc2);
-                expect($scope.side_bar_items.length).toBe(1);
-            })
-        });    
+//        describe('add_sidebar_item', function() {
+//            it("SideBarController add_sidebar_item test", function(){
+//                var acc1, acc2;
+//                ctrl.add_sidebar_items(acc1 = $scope.$new());
+//                ctrl.add_sidebar_items(acc2 = $scope.$new());
+//                expect($scope.side_bar_items.length).toBe(2);
+//            });
+//        });
+//
+//        describe('remove_side_bar_item', function(){
+//            it("SideBarController remove_side_bar test", function(){
+//                var acc1, acc2;
+//                ctrl.add_sidebar_items(acc1 = $scope.$new());
+//                ctrl.add_sidebar_items(acc2 = $scope.$new());
+//                ctrl.remove_side_bar_item(acc2);
+//                expect($scope.side_bar_items.length).toBe(1);
+//            })
+//        });    
     });
 });

--- a/src/sidebar/test/sidebar.spec.js
+++ b/src/sidebar/test/sidebar.spec.js
@@ -15,23 +15,23 @@ describe('sidebar', function () {
           ctrl = $controller('SideBarController', { $scope: $scope });
         }));
 
-//        describe('add_sidebar_item', function() {
-//            it("SideBarController add_sidebar_item test", function(){
-//                var acc1, acc2;
-//                ctrl.add_sidebar_items(acc1 = $scope.$new());
-//                ctrl.add_sidebar_items(acc2 = $scope.$new());
-//                expect($scope.side_bar_items.length).toBe(2);
-//            });
-//        });
-//
-//        describe('remove_side_bar_item', function(){
-//            it("SideBarController remove_side_bar test", function(){
-//                var acc1, acc2;
-//                ctrl.add_sidebar_items(acc1 = $scope.$new());
-//                ctrl.add_sidebar_items(acc2 = $scope.$new());
-//                ctrl.remove_side_bar_item(acc2);
-//                expect($scope.side_bar_items.length).toBe(1);
-//            })
-//        });    
+        describe('add_sidebar_item', function() {
+            it("SideBarController add_sidebar_item test", function(){
+                var acc1, acc2;
+                ctrl.add_sidebar_items(acc1 = $scope.$new());
+                ctrl.add_sidebar_items(acc2 = $scope.$new());
+                expect($scope.side_bar_items.length).toBe(2);
+            });
+        });
+
+        describe('remove_side_bar_item', function(){
+            it("SideBarController remove_side_bar test", function(){
+                var acc1, acc2;
+                ctrl.add_sidebar_items(acc1 = $scope.$new());
+                ctrl.add_sidebar_items(acc2 = $scope.$new());
+                ctrl.remove_side_bar_item(acc2);
+                expect($scope.side_bar_items.length).toBe(1);
+            })
+        });    
     });
 });

--- a/src/wizard/README.md
+++ b/src/wizard/README.md
@@ -11,20 +11,26 @@ This Wizard is a port of the angular-wizard by mgonto from [github](https://gith
 Usage
 --------------------
 ```html
-<wizard fullwidth="true">
-	<wizard-pane title="Step1">
-		<h1>Step 1</h1>
-		<form name="step1form">
-			<input type="text">
-			<input type="submit" wz-next>
-		</form>
-	</wizard-pane>
-	<wizard-pane title="Step2">
-		<h1>Step 2</h1>
-		<form name="step2form">
-			<input type="text">
-			<input type="submit" wz-finish>
-	</wizard-pane>
+<wizard fullwidth="true" on-finish="finished()" current-step="currentStep">
+  <wizard-pane title="Step1">
+    <h1>Step 1</h1>
+    <form name="step1form">
+        <div class="ui input">
+          <input type="text">
+        </div>
+      <button type="submit" class="ui button" wd-next>Next</button>
+    </form>
+  </wizard-pane>
+  <wizard-pane title="Step2">
+    <h1>Step 2</h1>
+    <form name="step2form">
+        <div class="ui input">
+          <input type="text">
+        </div>
+      <button type="submit" class="ui button" wd-finish>Finish</button>
+      <button type="submit" class="ui button" wd-previous>Previous</button>
+    </form>
+  </wizard-pane>
 </wizard>
 ```
 
@@ -32,6 +38,8 @@ Usage
 `wizard` - can have following attributes:
 
   * `fullwidth` - Go fullwidth for the steps bar;
+  * `current-step` - Updated each time a new step is selected
+  * `on-finish` - Function to call when a button with `wd-finish` will be clicked
 
 
 `wizard-pane` - can have the following attributes

--- a/src/wizard/doc/controllers.js
+++ b/src/wizard/doc/controllers.js
@@ -1,0 +1,13 @@
+
+angular
+  .module('dropdownApp', ['angularify.semantic.wizard'])
+  .controller('RootCtrl', RootCtrl);
+
+function RootCtrl ($scope) {
+    $scope.currentStep = '';
+  
+  $scope.callme = function () {
+    console.log('finished');
+  }
+}
+

--- a/src/wizard/doc/demo.html
+++ b/src/wizard/doc/demo.html
@@ -23,7 +23,7 @@
             <div class="ui input">
               <input type="text">
             </div>
-          <button type="submit" class="ui button" wd-next>Next</button>
+          <button type="submit" class="ui button" wz-next>Next</button>
         </form>
       </wizard-pane>
       <wizard-pane title="Step2">
@@ -32,7 +32,7 @@
             <div class="ui input">
               <input type="text">
             </div>
-          <button type="submit" class="ui button" wd-next>Next</button>
+          <button type="submit" class="ui button" wz-next>Next</button>
         </form>
       </wizard-pane>
       <wizard-pane title="Step3">
@@ -41,8 +41,8 @@
             <div class="ui input">
               <input type="text">
             </div>
-          <button type="submit" class="ui button" wd-finish>Finish</button>
-          <button type="submit" class="ui button" wd-previous>Previous</button>
+          <button type="submit" class="ui button" wz-finish>Finish</button>
+          <button type="submit" class="ui button" wz-previous>Previous</button>
         </form>
       </wizard-pane>
   </wizard>

--- a/src/wizard/doc/demo.html
+++ b/src/wizard/doc/demo.html
@@ -1,0 +1,54 @@
+<!DOCTYPE HTML>
+<html ng-app="dropdownApp">
+<head>
+  <meta charset="utf-8" />
+  <title>Semantic UI + Angular.JS</title>
+  <link href="../../../bower_components/semantic/dist/semantic.min.css" rel="stylesheet" type="text/css" />
+</head>
+<body ng-controller="RootCtrl">
+    <h2>Wizard</h2>
+  
+    <p class="ui info message">
+      Current step: <strong>{{ currentStep }}</strong>
+    </p>
+  
+    <p class="ui message" ng-show="isFinished">
+      Finished!
+    </p>
+  
+    <wizard fullwidth="true" on-finish="isFinished = true" current-step="currentStep">
+      <wizard-pane title="Step1">
+        <h1>Step 1</h1>
+        <form name="step1form">
+            <div class="ui input">
+              <input type="text">
+            </div>
+          <button type="submit" class="ui button" wd-next>Next</button>
+        </form>
+      </wizard-pane>
+      <wizard-pane title="Step2">
+        <h1>Step 2</h1>
+        <form name="step2form">
+            <div class="ui input">
+              <input type="text">
+            </div>
+          <button type="submit" class="ui button" wd-next>Next</button>
+        </form>
+      </wizard-pane>
+      <wizard-pane title="Step3">
+        <h1>Step 3</h1>
+        <form name="step3form">
+            <div class="ui input">
+              <input type="text">
+            </div>
+          <button type="submit" class="ui button" wd-finish>Finish</button>
+          <button type="submit" class="ui button" wd-previous>Previous</button>
+        </form>
+      </wizard-pane>
+  </wizard>
+    
+    <script src="../../../bower_components/angular/angular.min.js" type="text/javascript"></script>
+    <script src="../wizard.js" type="text/javascript"></script>
+    <script src="controllers.js" type="text/javascript"></script>
+</body>
+</html>

--- a/src/wizard/test/wizard.spec.js
+++ b/src/wizard/test/wizard.spec.js
@@ -1,0 +1,74 @@
+describe('wizard', function () {
+
+  beforeEach(module('angularify.semantic.wizard'));
+  
+  describe('controller', function () {
+    var controller,
+        scope;
+
+    beforeEach(inject(function ($controller, $rootScope) {    
+      scope = $rootScope.$new();
+      controller = $controller('WizardController', { $scope: scope });
+    }));
+
+    describe('with 2 steps', function() {
+      it("should contain 2 steps", function () {
+        controller.addStep({ title: 'step1' });
+        controller.addStep({ title: 'step2' });
+        expect(scope.steps.length).toBe(2);
+      });
+    });
+  });
+
+  describe('directive (wizard)', function () {
+    var controller,
+        scope,
+        elm;
+    
+    beforeEach(inject(function ($rootScope, $compile) {
+      scope = $rootScope;
+      elm = angular.element('<wizard fullwidth="true">' + 
+                              '<wizard-pane title="Step1"><h1>Step 1</h1></wizard-pane>' +
+                              '<wizard-pane title="Step2"><h1>Step 2</h1></wizard-pane>' +
+                              '<wizard-pane title="Step3"><h1>Step 3</h1></wizard-pane>' +
+                            '</wizard>');
+      $compile(elm)(scope);
+      scope.$digest();
+    }));
+               
+    it('should create a .steps div', function () {
+      expect(elm.find('.steps').length).toBe(1);
+    });
+    
+    it('should create a have class `three`', function () {
+      expect(elm.find('.steps').hasClass('three')).toBeTruthy();
+    });
+    
+    it('should contain 3 wizard pane', function () {
+      expect(elm.find('.ui.segment').length).toBe(3);
+    });    
+  });
+  
+  describe('directive (wizard-pane)', function () {
+    var controller,
+        scope,
+        elm,
+        subElm;
+    
+    beforeEach(inject(function ($rootScope, $compile) {
+      scope = $rootScope;
+      elm = angular.element('<wizard fullwidth="true"></wizard>');
+      subElm = angular.element('<wizard-pane title="Step1"><h1>Step 1</h1></wizard-pane>');
+      
+      elm.append(subElm);
+
+      $compile(elm)(scope);
+      scope.$digest();
+    }));
+               
+    
+    it('should contain a h1', function () {
+      expect(elm.find('h1').length).toBe(1);
+    });    
+  });
+});

--- a/src/wizard/wizard.js
+++ b/src/wizard/wizard.js
@@ -11,7 +11,7 @@ angular.module('angularify.semantic.wizard', [])
         $scope.$watch('currentStep', function (step) {
             if (!step) return;
             var stepTitle = $scope.selectedStep.title;
-            if ($scope.selectedStep && stepTitle !== $scope.currentStep) {           
+            if ($scope.selectedStep && stepTitle !== $scope.currentStep) {
                 $scope.goTo($scope.steps.filter(function (step) {
                     return step.title ==- $scope.currentStep;
                 })[0]);
@@ -184,7 +184,7 @@ function wizardButtonDirective(action) {
                         e.preventDefault();
                         $scope.$apply(function () {
                             $scope.$eval($attrs[action]);
-                            wizard[action.replace('wd', '').toLowerCase()]();
+                            wizard[action.replace('wz', '').toLowerCase()]();
                         });
                     });
                 }
@@ -192,7 +192,7 @@ function wizardButtonDirective(action) {
         });
 }
 
-wizardButtonDirective('wdNext');
-wizardButtonDirective('wdPrevious');
-wizardButtonDirective('wdFinish');
-wizardButtonDirective('wdCancel');
+wizardButtonDirective('wzNext');
+wizardButtonDirective('wzPrevious');
+wizardButtonDirective('wzFinish');
+wizardButtonDirective('wzCancel');

--- a/src/wizard/wizard.js
+++ b/src/wizard/wizard.js
@@ -2,69 +2,65 @@
 'use strict';
 angular.module('angularify.semantic.wizard', [])
 
-
-
 .controller('WizardController', ['$scope',
     function($scope) {
         $scope.steps = [];
         $scope.currentStep = null;
-        $scope.stepsLength = "";
-        $scope.$watch('currentStep', function(step) {
+        $scope.stepsLength = '';
+        
+        $scope.$watch('currentStep', function (step) {
             if (!step) return;
-            var stepTitle = $scope.selectedStep.title || $scope.selectedStep.wzTitle;
-            if ($scope.selectedStep && stepTitle !== $scope.currentStep) {
-                $scope.goTo(_.findWhere($scope.steps, {
-                    title: $scope.currentStep
-                }));
+            var stepTitle = $scope.selectedStep.title;
+            if ($scope.selectedStep && stepTitle !== $scope.currentStep) {           
+                $scope.goTo($scope.steps.filter(function (step) {
+                    return step.title ==- $scope.currentStep;
+                })[0]);
             }
         });
 
-        $scope.$watch('[editMode, steps.length]', function() {
+        $scope.$watch('[editMode, steps.length]', function () {
             var editMode = $scope.editMode;
-            if (_.isUndefined(editMode) || _.isNull(editMode)) return;
+            if (editMode === undefined || editMode === null) return;
 
             if (editMode) {
-                _.each($scope.steps, function(step) {
+                $scope.steps.forEach(function (step) {
                     step.completed = true;
                 });
             }
         }, true);
 
-
-
-
-        this.addStep = function(step) {
+        this.addStep = function (step) {
             $scope.steps.push(step);
             if ($scope.steps.length === 1) {
                 $scope.goTo($scope.steps[0]);
             }
         };
 
-        $scope.goTo = function(step) {
+        $scope.goTo = function (step) {
             unselectAll();
             $scope.selectedStep = step;
-            if (!_.isUndefined($scope.currentStep)) {
-                $scope.currentStep = step.title || step.wzTitle;
+          
+            if ($scope.currentStep !== undefined) {
+                $scope.currentStep = step.title;
             }
+          
             step.selected = true;
             $scope.$emit('wizard:stepChanged', {
                 step: step,
-                index: _.indexOf($scope.steps, step)
+                index: $scope.steps.indexOf(step)
             });
         };
 
         function unselectAll() {
-            _.each($scope.steps, function(step) {
+            $scope.steps.forEach(function (step) {
                 step.selected = false;
             });
             $scope.selectedStep = null;
         }
 
-        this.next = function(draft) {
-            var index = _.indexOf($scope.steps, $scope.selectedStep);
-            if (!draft) {
-                $scope.selectedStep.completed = true;
-            }
+        this.next = function () {
+            var index = $scope.steps.indexOf($scope.selectedStep);
+            $scope.selectedStep.completed = true;
             if (index === $scope.steps.length - 1) {
                 this.finish();
             } else {
@@ -72,31 +68,46 @@ angular.module('angularify.semantic.wizard', [])
             }
         };
 
-        this.goTo = function(step) {
+        this.goTo = function (step) {
             var stepTo;
-            if (_.isNumber(step)) {
+
+            if (angular.isNumber(step)) {
                 stepTo = $scope.steps[step];
             } else {
-                stepTo = _.findWhere($scope.steps, {
-                    title: step
-                });
+                stepTo = $scope.steps.filter(function (step) {
+                    return step.title === step;
+                })[0];
             }
             $scope.goTo(stepTo);
         };
 
         this.finish = function() {
             if ($scope.onFinish) {
+                $scope.selectedStep.completed = true;
                 $scope.onFinish();
             }
         };
 
         this.cancel = this.previous = function() {
-            var index = _.indexOf($scope.steps, $scope.selectedStep);
+            var index = $scope.steps.indexOf($scope.selectedStep);
             if (index === 0) {
                 throw new Error('Cant go back. Its already in step 0');
             } else {
                 $scope.goTo($scope.steps[index - 1]);
             }
+        };
+
+        $scope.getStatus = function (step) {
+          var statusClass = [];
+            
+          if (step.selected)
+            statusClass.push('active');
+          if (!step.selected && !step.completed)
+            statusClass.push('disabled');
+          if (step.completed)
+            statusClass.push('completed');
+
+          return statusClass;
         };
     }
 ])
@@ -107,14 +118,21 @@ angular.module('angularify.semantic.wizard', [])
             transclude: true,
             scope: {
                 fullwidth: "@",
-                currentStep: '=',
+                currentStep: '=?',
                 onFinish: '&',
-                hideIndicators: '=',
                 editMode: '=',
                 name: '@'
             },
             controller: 'WizardController',
-            template: '<div><div class="ui steps {{stepsLength}} small"><div class="ui step" ng-repeat="step in steps" ng-click="!step.completed || goTo(step)" ng-class="{disabled: !step.completed && !step.selected, active: step.selected && !step.completed, done: step.completed && !step.selected, editing: step.selected && step.completed}">{{step.title}}</div></div><div ng-transclude></div></div>',
+            template: '<div>' + 
+                        '<div class="ui steps {{stepsLength}} small">' + 
+                          '<div class="ui step" ng-repeat="step in steps" ng-click="step.completed && goTo(step)" ng-class="getStatus(step)">' + 
+                            '{{step.title}}' + 
+                          '</div>' + 
+                        '</div>' + 
+                        '<div class="ui hidden divider"></div>' +
+                        '<div ng-transclude></div>' + 
+                      '</div>',
             link: function(scope, element, attrs, WizardController) {
                 if (scope.fullwidth === 'true') {
                     var widthmatrix = {
@@ -146,29 +164,27 @@ angular.module('angularify.semantic.wizard', [])
             scope: {
                 title: '@'
             },
-            template: '<div class="ui segment" ng-transclude ng-show="selected"></div>',
+            template: '<div class="ui segment" ng-transclude ng-show="selected" ng-style="noMargin"></div>',
             link: function(scope, element, attrs, WizardController) {
-
                 WizardController.addStep(scope);
             }
         };
     });
 
-
 function wizardButtonDirective(action) {
     angular.module('angularify.semantic.wizard')
-        .directive(action, function() {
+        .directive(action, function () {
             return {
                 restrict: 'A',
                 replace: false,
                 require: '^wizard',
-                link: function($scope, $element, $attrs, wizard) {
-
-                    $element.on('click', function(e) {
+                link: function ($scope, $element, $attrs, wizard) {
+                    $scope.noMargin = { margin: 0 };
+                    $element.on('click', function (e) {
                         e.preventDefault();
-                        $scope.$apply(function() {
+                        $scope.$apply(function () {
                             $scope.$eval($attrs[action]);
-                            wizard[action.replace("wz", "").toLowerCase()]();
+                            wizard[action.replace('wd', '').toLowerCase()]();
                         });
                     });
                 }
@@ -176,7 +192,7 @@ function wizardButtonDirective(action) {
         });
 }
 
-wizardButtonDirective('wzNext');
-wizardButtonDirective('wzPrevious');
-wizardButtonDirective('wzFinish');
-wizardButtonDirective('wzCancel');
+wizardButtonDirective('wdNext');
+wizardButtonDirective('wdPrevious');
+wizardButtonDirective('wdFinish');
+wizardButtonDirective('wdCancel');


### PR DESCRIPTION
As reported on #12, the active state should only depend on `step.selected`.
I noticed wizard component needs `lodash`. I replaced all their call by native javascript methods in order to remove this dependency requirement. 

README.md has been updated to add the missing part of the example.