### PR TITLE
Only use minified version for production

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,6 @@
     }
   ],
   "main": [
-    "dist/angular-semantic-ui.js",
     "dist/angular-semantic-ui.min.js"
   ],
   "ignore": [


### PR DESCRIPTION
Hi,

When we use a script to inject our dependencie on our index.html file it will look at the `main` option. We need to only have on file on this option.