### PR TITLE
Return nothing if popup is not the desired purpose

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -13,6 +13,10 @@ angular.module('angularify.semantic.popup', [])
             // convert to json
             var popup_meta_data = eval('(' + scope.popup + ')');
             
+            if (popup_meta_data === undefined) {
+                return;
+            }
+            
             var title = popup_meta_data['title'];
             if (title == undefined)
                 title = '';


### PR DESCRIPTION
Hi,

There are a lot of errors on this directive, like the use of `eval()` and many other little things...

```javascript
var title = popup_meta_data['title'];
if (title == undefined)
    title = ''
```
can be...
```javascript
var title = popup_meta_data['title'] || '';
```

But, the main problem here is that `popup` is to generic! I've other package who use this HTML option (`data-popup`) and without a test to be sure that `popup_meta_data` is not undefined I've got a lot of error in my console.

This is just a hack. But I think you need to remove completly this component and use some convention like `asm-popup` or whatever (`sm-*` is used by the real Semantic-UI Angular component).