### PR TITLE
Hide and destroy modal when scope gets destroyed

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -21,6 +21,7 @@ angular.module('angularify.semantic.modal', [])
             element.modal(modelValue ? 'show' : 'hide');
           });
           scope.$on('$destroy', function() {
+            element.modal('hide');
             element.remove();
           });
         }

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -20,6 +20,9 @@ angular.module('angularify.semantic.modal', [])
           }, function (modelValue){
             element.modal(modelValue ? 'show' : 'hide');
           });
+          scope.$on('$destroy', function() {
+            element.remove();
+          });
         }
     }
 });


### PR DESCRIPTION
When the scope of a modal gets destroyed, the modal should also be removed from the dom. Otherwise it will stack them when you for example change views in ui-router or a different view router.

Simple but effective, and in my case, important fix.