### PR TITLE
Don't use separate scope in modals

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -7,6 +7,7 @@ angular.module('angularify.semantic.modal', [])
         restrict: 'E',
         replace: true,
         transclude: true,
+        scope: false,
         require: 'ngModel',
         template: '<div class="ui modal" ng-transclude></div>',
         link: function (scope, element, attrs, ngModel) {          


### PR DESCRIPTION
By setting scope to false you can use the scope from the controller where the model is used in.

I think you should either this setting, or there should be an option to assign a new controller and inject stuff from the other controller.
