### PR TITLE
add merge of additionalOptions from within the scope into modal instance

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -15,6 +15,15 @@ angular.module('angularify.semantic.modal', [])
               ngModel.$setViewValue(false);
             }
           });
+	  var options = {
+                onHide: function () {
+                    ngModel.$setViewValue(false);
+              }
+          };
+          if (scope.additionalOptions != undefined) {
+              for (var attrname in scope.additionalOptions) { options[attrname] = scope.additionalOptions[attrname]; }
+          }
+          element.modal(options);
           scope.$watch(function () {
             return ngModel.$modelValue;
           }, function (modelValue){


### PR DESCRIPTION
Enable the setting of additional options to the modal instance. 

These options should be property additionalOptions, of the scope, for merging this into the default modal options set in the directive.
