### PR TITLE
add merge of additionalOptions object from the scope into modal instance options 

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -9,12 +9,16 @@ angular.module('angularify.semantic.modal', [])
         transclude: true,
         require: 'ngModel',
         template: '<div class="ui modal" ng-transclude></div>',
-        link: function (scope, element, attrs, ngModel) {          
-          element.modal({
+        link: function (scope, element, attrs, ngModel) {
+	      var options = {
             onHide: function () {
-              ngModel.$setViewValue(false);
+                ngModel.$setViewValue(false);
             }
-          });
+          };
+          if (scope.additionalOptions != undefined) {
+              for (var attrname in scope.additionalOptions) { options[attrname] = scope.additionalOptions[attrname]; }
+          }
+          element.modal(options);
           scope.$watch(function () {
             return ngModel.$modelValue;
           }, function (modelValue){


### PR DESCRIPTION
Enable the setting of additional options to the modal instance.
These options should be property additionalOptions, of the scope, which gets merged into the default modal options object in the directive.
Without a change like this one, it is not possible to set modal options other than the default from the directive..
